### PR TITLE
Use button instead of div

### DIFF
--- a/js/src/components/case.tsx
+++ b/js/src/components/case.tsx
@@ -28,9 +28,15 @@ const TestCase: React.FC<Prop> = (props) => {
           <Col>{props.case.name}</Col>
           <Col flex="auto"></Col>
           <Col>
-            <div onClick={() => setShowModal(true)}>
+            <button
+              onClick={() => setShowModal(true)}
+              style={{
+                background: "none",
+                border: "none",
+              }}
+            >
               <BugFilled />
-            </div>
+            </button>
           </Col>
         </Row>
       </div>


### PR DESCRIPTION
buttons should be used instead of clickable divs in order to allow keyboard navigation and improve accessibility. WRT styling:
- there's a small margin-right that's added because of buttons, but I left it in because I think the margin looks better
- no other styles are changed (checked on Chrome 85.0.4183.121, Firefox 81.0, and Safari 14.0.1 (16610.2.6.1.6))

in the future, we might want to make the entire row clickable (IMO clicking the icon at the right isn't super intuitive)