### PR TITLE
Add terraform modules to manage things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ dmypy.json
 # End of https://www.toptal.com/developers/gitignore/api/python,macos
 *.ipynb
 *.bak
+
+# Terraform
+.terraform

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,52 @@
+# Setup Instructions
+
+Assumption: You have valid AWS credentials configured in your shell.
+
+## Step 0: Remote State Resources
+
+_Note: Unless you're deploying into a new AWS Account you shouldn't need to deal with
+this step._
+
+To set up the resources necessary you'll go into the remote-state module and
+apply it. Like so:
+
+```bash
+cd remote-state
+
+terraform init
+terraform apply # If the changes are what you expect, enter yes when prompted
+```
+
+Now we need to pass our outputs back for the primary module to use
+
+```
+terraform output > ../backend.hcl
+```
+
+## Step 1: Init
+
+```bash
+terraform init -backend-config=./backend.hcl
+```
+
+## Step 2: Apply
+
+```bash
+terraform apply
+```
+
+## Step 3: Manual steps
+
+### Create access keys for our two AWS users:
+
+```bash
+aws iam create-access-key --user-name travis-logs-uploader
+aws iam create-access-key --user-name travis-site-uploader
+```
+
+And stash the keys into the appropriate CI secrets mechanism.
+
+### Update DNS
+
+Grab the cloudfront distribution & ACM validation records and update the
+appropriate DNS records.

--- a/terraform/acm_certificate.tf
+++ b/terraform/acm_certificate.tf
@@ -1,0 +1,18 @@
+resource "aws_acm_certificate" "site" {
+  domain_name = var.domains[0]
+
+  subject_alternative_names = slice(var.domains, 1, length(var.domains)) # Ugh
+  validation_method         = "DNS"
+
+  provider = aws.cloudfront
+}
+
+
+resource "aws_acm_certificate_validation" "site" {
+  provider = aws.cloudfront
+
+  certificate_arn = aws_acm_certificate.site.arn
+
+  # TODO: For whenever we can manage these domains in route53
+  # validation_record_fqdns = []
+}

--- a/terraform/backend.hcl
+++ b/terraform/backend.hcl
@@ -1,0 +1,4 @@
+bucket = osstravistracker-tfstate-dd662b489f6ec86d
+dynamodb_table = terraform-state-lock
+key = terraform.tfstate
+region = us-west-2

--- a/terraform/cloudfront.tf
+++ b/terraform/cloudfront.tf
@@ -1,0 +1,71 @@
+locals {
+  s3_origin_id = "S3-ray-travis-site"
+}
+
+resource "aws_cloudfront_distribution" "site" {
+  enabled = "true"
+
+  aliases = var.domains
+
+  origin {
+    origin_id = local.s3_origin_id
+
+    domain_name = aws_s3_bucket.site.bucket_regional_domain_name
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.site.cloudfront_access_identity_path
+    }
+  }
+
+  default_root_object = "index.html"
+  custom_error_response {
+    error_caching_min_ttl = "0"
+    error_code            = "404"
+    response_code         = "404"
+    response_page_path    = "/404.html"
+  }
+
+  default_cache_behavior {
+    target_origin_id       = local.s3_origin_id
+    allowed_methods        = ["HEAD", "GET"]
+    cached_methods         = ["HEAD", "GET"]
+    compress               = "true"
+    default_ttl            = "300" # 60s * 5m
+    max_ttl                = "600" # 60s * 10m
+    min_ttl                = "0"
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate.site.arn
+    minimum_protocol_version = "TLSv1.2_2019"
+    ssl_support_method       = "sni-only"
+  }
+
+  is_ipv6_enabled = "true"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  lifecycle {
+    # Altering this in prod involves extra manual work. Please be sure you want to do this :D
+    prevent_destroy = true
+  }
+
+  depends_on = [aws_acm_certificate_validation.site]
+  provider   = aws.cloudfront
+}
+
+resource "aws_cloudfront_origin_access_identity" "site" {
+  comment = "access-identity-ray-travis-site"
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,0 +1,77 @@
+resource "aws_iam_user" "logs_uploader" {
+  name = "travis-logs-uploader"
+}
+
+resource "aws_iam_user_policy" "uploader_writeonly_logs" {
+  name = "write-only-to-bucket"
+
+  user   = aws_iam_user.logs_uploader.name
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Action": "s3:PutObject",
+      "Effect": "Allow",
+      "Resource": "${aws_s3_bucket.logs.arn}/*",
+      "Sid": "write"
+    }
+  ],
+  "Version": "2012-10-17"
+}
+POLICY
+}
+
+resource "aws_iam_user" "site_uploader" {
+  name = "travis-site-uploader"
+}
+
+resource "aws_iam_user_policy" "uploader_readonly_logs" {
+  name = "readonly-logs-bucket"
+
+  user   = aws_iam_user.site_uploader.name
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.logs.arn}",
+        "${aws_s3_bucket.logs.arn}/*"
+      ],
+      "Sid": "read"
+    }
+  ],
+  "Version": "2012-10-17"
+}
+POLICY
+}
+
+resource "aws_iam_user_policy" "uploader_readwrite_site" {
+  name = "readwrite-site-bucket"
+
+  user   = aws_iam_user.site_uploader.name
+  policy = <<POLICY
+{
+  "Statement": [
+    {
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.site.arn}",
+        "${aws_s3_bucket.site.arn}/*"
+      ],
+      "Sid": "readwrite"
+    }
+  ],
+  "Version": "2012-10-17"
+}
+POLICY
+}

--- a/terraform/remote-state/main.tf
+++ b/terraform/remote-state/main.tf
@@ -1,0 +1,48 @@
+resource "random_id" "name_suffix" {
+  byte_length = 8
+}
+
+locals {
+  name = join("-", compact([
+    var.state_prefix,
+    "tfstate",
+    random_id.name_suffix.hex,
+  ]))
+}
+
+resource "aws_s3_bucket" "state_bucket" {
+  bucket = local.name
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "state_bucket" {
+  bucket = aws_s3_bucket.state_bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+
+resource "aws_dynamodb_table" "state_lock_table" {
+  name         = "terraform-state-lock"
+  billing_mode = "PAY_PER_REQUEST"
+
+  hash_key = "LockID"
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+}

--- a/terraform/remote-state/outputs.tf
+++ b/terraform/remote-state/outputs.tf
@@ -1,0 +1,15 @@
+output "bucket" {
+  value = aws_s3_bucket.state_bucket.id
+}
+
+output "region" {
+  value = aws_s3_bucket.state_bucket.region
+}
+
+output "dynamodb_table" {
+  value = aws_dynamodb_table.state_lock_table.id
+}
+
+output "key" {
+  value = "terraform.tfstate"
+}

--- a/terraform/remote-state/terraform.tfstate
+++ b/terraform/remote-state/terraform.tfstate
@@ -1,0 +1,169 @@
+{
+  "version": 4,
+  "terraform_version": "0.13.3",
+  "serial": 24,
+  "lineage": "14895042-bf41-1b85-7e71-47a29ecc5a3c",
+  "outputs": {
+    "bucket": {
+      "value": "osstravistracker-tfstate-dd662b489f6ec86d",
+      "type": "string"
+    },
+    "dynamodb_table": {
+      "value": "terraform-state-lock",
+      "type": "string"
+    },
+    "key": {
+      "value": "terraform.tfstate",
+      "type": "string"
+    },
+    "region": {
+      "value": "us-west-2",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_dynamodb_table",
+      "name": "state_lock_table",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 1,
+          "attributes": {
+            "arn": "arn:aws:dynamodb:us-west-2:035372728034:table/terraform-state-lock",
+            "attribute": [
+              {
+                "name": "LockID",
+                "type": "S"
+              }
+            ],
+            "billing_mode": "PAY_PER_REQUEST",
+            "global_secondary_index": [],
+            "hash_key": "LockID",
+            "id": "terraform-state-lock",
+            "local_secondary_index": [],
+            "name": "terraform-state-lock",
+            "point_in_time_recovery": [
+              {
+                "enabled": true
+              }
+            ],
+            "range_key": null,
+            "read_capacity": 0,
+            "replica": [],
+            "server_side_encryption": [],
+            "stream_arn": "",
+            "stream_enabled": false,
+            "stream_label": "",
+            "stream_view_type": "",
+            "tags": {},
+            "timeouts": null,
+            "ttl": [
+              {
+                "attribute_name": "",
+                "enabled": false
+              }
+            ],
+            "write_capacity": 0
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjo2MDAwMDAwMDAwMDAsImRlbGV0ZSI6NjAwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMDB9LCJzY2hlbWFfdmVyc2lvbiI6IjEifQ=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "state_bucket",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acceleration_status": "",
+            "acl": "private",
+            "arn": "arn:aws:s3:::osstravistracker-tfstate-dd662b489f6ec86d",
+            "bucket": "osstravistracker-tfstate-dd662b489f6ec86d",
+            "bucket_domain_name": "osstravistracker-tfstate-dd662b489f6ec86d.s3.amazonaws.com",
+            "bucket_prefix": null,
+            "bucket_regional_domain_name": "osstravistracker-tfstate-dd662b489f6ec86d.s3.us-west-2.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": false,
+            "grant": [],
+            "hosted_zone_id": "Z3BJ6K6RIION7M",
+            "id": "osstravistracker-tfstate-dd662b489f6ec86d",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "policy": null,
+            "region": "us-west-2",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [],
+            "tags": {},
+            "versioning": [
+              {
+                "enabled": true,
+                "mfa_delete": false
+              }
+            ],
+            "website": [],
+            "website_domain": null,
+            "website_endpoint": null
+          },
+          "private": "bnVsbA==",
+          "dependencies": [
+            "random_id.name_suffix"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket_public_access_block",
+      "name": "state_bucket",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "block_public_acls": true,
+            "block_public_policy": true,
+            "bucket": "osstravistracker-tfstate-dd662b489f6ec86d",
+            "id": "osstravistracker-tfstate-dd662b489f6ec86d",
+            "ignore_public_acls": true,
+            "restrict_public_buckets": true
+          },
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_s3_bucket.state_bucket",
+            "random_id.name_suffix"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "random_id",
+      "name": "name_suffix",
+      "provider": "provider[\"registry.terraform.io/hashicorp/random\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "b64": "3WYrSJ9uyG0",
+            "b64_std": "3WYrSJ9uyG0=",
+            "b64_url": "3WYrSJ9uyG0",
+            "byte_length": 8,
+            "dec": "15953486320919038061",
+            "hex": "dd662b489f6ec86d",
+            "id": "3WYrSJ9uyG0",
+            "keepers": null,
+            "prefix": null
+          },
+          "private": "bnVsbA=="
+        }
+      ]
+    }
+  ]
+}

--- a/terraform/remote-state/terraform.tfvars
+++ b/terraform/remote-state/terraform.tfvars
@@ -1,0 +1,1 @@
+state_prefix = "osstravistracker"

--- a/terraform/remote-state/variables.tf
+++ b/terraform/remote-state/variables.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.9.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "2.3.0"
+    }
+  }
+
+  backend "local" {}
+}
+
+variable "state_prefix" {
+  type        = string
+  description = "What to prefix to the state bucket to make it slightly more identifiable"
+  default     = ""
+}

--- a/terraform/s3.tf
+++ b/terraform/s3.tf
@@ -1,0 +1,87 @@
+# Account settings
+
+resource "aws_s3_account_public_access_block" "account" {
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Job Logs bucket
+
+resource "aws_s3_bucket" "logs" {
+  bucket = "ray-travis-logs"
+
+  versioning {
+    enabled = "true"
+  }
+
+  lifecycle {
+    # Destroying this bucket will cause unrecoverable lose of build history
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+
+# Website Bucket
+
+resource "aws_s3_bucket" "site" {
+  bucket = "ray-travis-site"
+
+  versioning {
+    enabled = "true"
+  }
+
+  lifecycle {
+    # Destroying this bucket will cause the site to go offline
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "site" {
+  bucket = aws_s3_bucket.site.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+
+resource "aws_s3_bucket_policy" "site" {
+  bucket = aws_s3_bucket.site.id
+
+  # Note: we need both List & Get to make the 404s work with cloudfront
+  policy = <<POLICY
+{
+  "Id": "PolicyForCloudFrontPrivateContent",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${aws_cloudfront_origin_access_identity.site.iam_arn}"
+      },
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.site.arn}",
+        "${aws_s3_bucket.site.arn}/*"
+      ],
+      "Sid": "read"
+    }
+  ],
+  "Version": "2008-10-17"
+}
+POLICY
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.9.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+provider "aws" {
+  alias = "cloudfront"
+
+  region = "us-east-1"
+}
+
+variable "domains" {
+  type        = list(string)
+  description = "Which domains are we serving the site from?"
+  default     = ["flakey-tests.ray.io", "flaky-tests.ray.io"]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,6 +5,8 @@ terraform {
       version = "3.9.0"
     }
   }
+
+  backend "s3" {}
 }
 
 provider "aws" {


### PR DESCRIPTION
### Summary

Adds the various terraform modules we're using to manage the AWS infra running `flaky-tests.ray.io`

### Testing Done

Its currently up and plan doesn't return any changes :D

```bash
$ terraform plan
Acquiring state lock. This may take a few moments...
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

aws_acm_certificate.site: Refreshing state... [id=arn:aws:acm:us-east-1:035372728034:certificate/67196bf7-5461-4368-a231-3e0dfd2d5dfc]
aws_cloudfront_origin_access_identity.site: Refreshing state... [id=E35EGNLPBV7GUF]
aws_iam_user.logs_uploader: Refreshing state... [id=travis-logs-uploader]
aws_s3_account_public_access_block.account: Refreshing state... [id=035372728034]
aws_iam_user.site_uploader: Refreshing state... [id=travis-site-uploader]
aws_s3_bucket.site: Refreshing state... [id=ray-travis-site]
aws_s3_bucket.logs: Refreshing state... [id=ray-travis-logs]
aws_acm_certificate_validation.site: Refreshing state... [id=2020-09-23 21:06:06 +0000 UTC]
aws_s3_bucket_policy.site: Refreshing state... [id=ray-travis-site]
aws_iam_user_policy.uploader_readwrite_site: Refreshing state... [id=travis-site-uploader:readwrite-site-bucket]
aws_s3_bucket_public_access_block.site: Refreshing state... [id=ray-travis-site]
aws_cloudfront_distribution.site: Refreshing state... [id=E3KI3V4LTODRXU]
aws_iam_user_policy.uploader_readonly_logs: Refreshing state... [id=travis-site-uploader:readonly-logs-bucket]
aws_iam_user_policy.uploader_writeonly_logs: Refreshing state... [id=travis-logs-uploader:write-only-to-bucket]
aws_s3_bucket_public_access_block.logs: Refreshing state... [id=ray-travis-logs]

------------------------------------------------------------------------

No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, no
actions need to be performed.
Releasing state lock. This may take a few moments...
```