### PR TITLE
Check if 'nightly' Docker images are being built

### DIFF
--- a/docker_checker.py
+++ b/docker_checker.py
@@ -11,7 +11,7 @@ from fetch_and_render import get_latest_commit
 ARCH_VERSIONS = ["-cpu", "-gpu", ""]
 IMAGES_TO_CHECK = ["ray", "ray-ml"]
 MAX_TIME_FOR_DOCKER_BUILD = timedelta(hours=3)
-PYTHON_VERSIONS = ["py36", "py37", "py38"]
+PYTHON_VERSIONS = ["-py36", "-py37", "-py38", ""]
 
 
 def get_most_recent_layer(tag_resp: Dict[str, Any]) -> datetime:
@@ -50,7 +50,7 @@ def check_last_updated_for_repo(image_name: str, tag_prefix="nightly") -> Dict[s
     with concurrent.futures.ThreadPoolExecutor() as executor:
         for py_version in PYTHON_VERSIONS:
             for arch in ARCH_VERSIONS:
-                tag = f"{tag_prefix}-{py_version}{arch}"
+                tag = f"{tag_prefix}{py_version}{arch}"
                 results[f"{image_name}/{tag}"] = executor.submit(fetch_manifest_time, image_name, tag, token)
     
     for tag, fut in results.items():

--- a/docker_checker.py
+++ b/docker_checker.py
@@ -77,6 +77,7 @@ def check_recent_commits_have_docker_build() -> List[str]:
     # are only built per commit (e.g. there may be no images built for 
     # 48 hours over a weekend if there are no commits).
     sha, commit_time = find_commit_of_age(MAX_TIME_FOR_DOCKER_BUILD)
+    sha = sha[:6]
     all_images =  check_last_updated_for_repo("ray")
     all_images.update(check_last_updated_for_repo("ray-ml"))
     failed = []

--- a/docker_checker.py
+++ b/docker_checker.py
@@ -1,0 +1,75 @@
+import concurrent.futures
+from dateutil.parser import parse as date_parser
+from datetime import datetime, timedelta
+import json
+import pytz
+import requests
+from typing import Any, Dict, List, Optional, Tuple
+
+from fetch_and_render import get_latest_commit
+
+ARCH_VERSIONS = ["-cpu", "-gpu", ""]
+IMAGES_TO_CHECK = ["ray", "ray-ml"]
+MAX_TIME_FOR_DOCKER_BUILD = timedelta(hours=3)
+PYTHON_VERSIONS = ["py36", "py37", "py38"]
+
+
+def get_most_recent_layer(tag_resp: Dict[str, Any]) -> datetime:
+    # First index is the newest
+    dates = []
+    for layer in tag_resp["history"]:
+        layer_json = json.loads(layer["v1Compatibility"])
+        dates.append(date_parser(layer_json["created"]).replace(tzinfo=pytz.utc))
+    return max(dates)
+
+def fetch_manifest(image_name: str, tag: str, token: str) -> datetime:
+    manifest_url = f"https://registry.hub.docker.com/v2/rayproject/{image_name}/manifests/{tag}"
+    manifest_resp = requests.get(manifest_url,headers={"Authorization": f"Bearer {token}"})
+    assert manifest_resp.ok
+    return get_most_recent_layer(manifest_resp.json())
+    
+
+
+def check_last_updated_for_repo(image_name: str, tag_prefix="nightly") -> Dict[str, datetime]:
+    token_url = f"https://auth.docker.io/token?service=registry.docker.io&scope=repository:rayproject/{image_name}:pull"
+    token_resp = requests.get(token_url)
+    assert token_resp.ok
+    token = token_resp.json()["token"]
+
+    results = {}
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        for py_version in PYTHON_VERSIONS:
+            for arch in ARCH_VERSIONS:
+                tag = f"{tag_prefix}-{py_version}{arch}"
+                results[f"{image_name}/{tag}"] = executor.submit(fetch_manifest, image_name, tag, token)
+    
+    for tag, fut in results.items():
+        results[tag] = fut.result()
+    return results
+
+def find_commit_of_age(age=timedelta(hours=4)) -> Tuple[str, datetime]:
+    # UTC Time
+    recent_commits = get_latest_commit()
+    now = datetime.now(tz=pytz.utc)
+    for commit in recent_commits:
+        created_at = datetime.fromtimestamp(commit.unix_time_s, tz=pytz.utc)
+        if (now - age) > created_at:
+            return (commit.sha, created_at)
+
+
+
+def check_recent_commits_have_docker_build() -> List[str]:
+    sha, commit_time = find_commit_of_age(MAX_TIME_FOR_DOCKER_BUILD)
+    all_images =  check_last_updated_for_repo("ray")
+    all_images.update(check_last_updated_for_repo("ray-ml"))
+    failed = []
+    for tag, date in all_images.items():
+        if date < commit_time:
+            failed.append(f"- `{tag}` did not build for SHA: `{sha}`")
+    if len(failed) == 0:
+        return []
+    lines = [
+        "🐳 Your Docker Build Failure Report", 
+    ]
+    lines.extend(failed)
+    return lines

--- a/slack_fail_runner.py
+++ b/slack_fail_runner.py
@@ -35,7 +35,7 @@ GROUP BY test_name
 """
     )
 )
-failed_docker_builds = check_recent_commits_have_docker_build
+failed_docker_builds = check_recent_commits_have_docker_build()
 if len(failed_tests) == 0 and len(failed_docker_builds) == 0:
     print("No failed cases, skipping.")
     sys.exit(0)

--- a/slack_fail_runner.py
+++ b/slack_fail_runner.py
@@ -6,6 +6,8 @@ import sys
 from datetime import datetime
 import pytz
 
+from docker_checker import check_recent_commits_have_docker_build
+
 current_time_pacific = (
     datetime.utcnow()
     .replace(tzinfo=pytz.utc)
@@ -33,14 +35,19 @@ GROUP BY test_name
 """
     )
 )
-if len(failed_tests) == 0:
+failed_docker_builds = check_recent_commits_have_docker_build
+if len(failed_tests) == 0 and len(failed_docker_builds) == 0:
     print("No failed cases, skipping.")
     sys.exit(0)
 
-markdown_lines = ["🚧 Your Failing Test Report"]
-for name, count in failed_tests:
-    markdown_lines.append(f"- `{name}` failed *{count}* times over latest 5 commits")
-markdown_lines.append("Go to https://flakey-tests.ray.io/ to view Travis links")
+markdown_lines = []
+if len(failed_tests) != 0
+    markdown_lines.append("🚧 Your Failing Test Report")
+    for name, count in failed_tests:
+        markdown_lines.append(f"- `{name}` failed *{count}* times over latest 5 commits")
+    markdown_lines.append("Go to https://flakey-tests.ray.io/ to view Travis links")
+
+markdown_lines.extend(failed_docker_builds)
 slack_url = os.environ["SLACK_WEBHOOK"]
 slack_channnel = os.environ.get("SLACK_CHANNEL_OVERRIDE", "#oss-test-cop")
 


### PR DESCRIPTION
* Checks if `nightly` image has been built since a recent commit (recent is defined as a commit that is at least **3** hours old). We use an image that is this old because we want a) it to have enough time for docker build to complete and b) be tied to a commit in the event that it has been a while since a commit was made.