### PR TITLE
log message if we cannot fetch tag for test

### DIFF
--- a/ray_ci_tracker/common.py
+++ b/ray_ci_tracker/common.py
@@ -86,13 +86,16 @@ def _yield_test_result(bazel_log_path):
     with open(bazel_log_path) as f:
         for line in f:
             loaded = json.loads(line)
-            if "targetConfigured" in loaded["id"] and "configured" in loaded and "tag" in loaded["configured"]:
+            if "targetConfigured" in loaded["id"]:
                 test_name = loaded["id"]["targetConfigured"]["label"]
-                for tag in loaded["configured"]["tag"]:
-                    if tag == "flaky":
-                        flaky_tests.add(test_name)
-                    if tag.startswith("team:"):
-                        test_owners[test_name] = tag.replace("team:", "")
+                if "configured" in loaded and "tag" in loaded["configured"]:
+                    for tag in loaded["configured"]["tag"]:
+                        if tag == "flaky":
+                            flaky_tests.add(test_name)
+                        if tag.startswith("team:"):
+                            test_owners[test_name] = tag.replace("team:", "")
+                else:
+                    print(f'could not fetch tags for test {test_name}, cannot determine if it is flaky. Raw dump: {json.dumps(loaded)}')
             if (
                 "configuration" in loaded["id"]
                 and "makeVariable" in loaded["configuration"]


### PR DESCRIPTION
Signed-off-by: Clarence Ng <clarence.wyng@gmail.com>

Test results with a malformed log file:

could not fetch tags for test //:memory_monitor_test, cannot determine if it is flaky. Raw dump: {"id":{"targetConfigured":{"label":"\/\/:memory_monitor_test"}},"children":[{"targetCompleted":{"label":"\/\/:memory_monitor_test","configuration":{"id":"118493d06af2cdbddfd4c3f2194f8aeebfd111a551c790cbaccfc98bb06f663e"}}}]}
TestResult(test_name='//:memory_monitor_test', status='PASSED', total_duration_s=0.189, is_labeled_flaky=False, owner='unknown', is_labeled_staging=False)