### PR TITLE
[go/flaky] incorporate flaky test state

### DIFF
--- a/js/src/components/case.tsx
+++ b/js/src/components/case.tsx
@@ -47,7 +47,7 @@ const TestCase: React.FC<Prop> = (props) => {
         >
           <Row>
             <Col>{props.case.name}</Col>
-            {props.case.is_labeled_flaky && <Col span={2}>❆</Col>}
+            {props.case.is_labeled_flaky && <Col span={2}> 🥶</Col>}
 
             <Col flex="auto"></Col>
 


### PR DESCRIPTION
Incorporate flaky test state + render green metric which exclude flaky tests. Also use a little bit more clearer icon for flaky tests.

<img width="1453" alt="Screenshot 2024-01-19 at 8 42 32 AM" src="https://github.com/ray-project/travis-tracker-v2/assets/128072568/d795a78e-d0f3-49bf-977b-47ff2877cb7d">
