### PR TITLE
[go/flaky] remove some metrics + ui tweak

### DIFF
--- a/js/src/components/case.tsx
+++ b/js/src/components/case.tsx
@@ -47,7 +47,7 @@ const TestCase: React.FC<Prop> = (props) => {
         >
           <Row>
             <Col>{props.case.name}</Col>
-            {props.case.is_labeled_flaky && <Col span={2}> 🥶</Col>}
+            {props.case.is_labeled_flaky && <Col span={2}>🥶</Col>}
 
             <Col flex="auto"></Col>
 


### PR DESCRIPTION
- Remove windows metrics (let's focus on window + flaky)
- Remove build P50 (the number is incorrect)
- Desire greenest is 20 (1 green in 5 working days)
- UI tweak on the cold icon, remove the space, it looks fine without it


<img width="1864" alt="Screenshot 2024-01-22 at 6 01 02 PM" src="https://github.com/ray-project/travis-tracker-v2/assets/128072568/a6a2b438-517e-4415-be83-0468bf9a8d24">

