### PR TITLE
[ci] change metric to green if greater than

### DIFF
--- a/js/src/components/stat.tsx
+++ b/js/src/components/stat.tsx
@@ -15,7 +15,7 @@ const StatsPane: React.FC<Prop> = ({ stats }) => (
             title={s.key}
             value={s.value.toFixed(0)}
             valueStyle={{
-              color: s.value === s.desired_value ? "green" : "red",
+              color: s.value >= s.desired_value ? "green" : "red",
               textAlign: "right",
             }}
             suffix={s.unit}


### PR DESCRIPTION
Currently the metric on go/flaky only turns green when it is an exact match (see the 24% number). Change it to green if it is greater than.

<img width="1851" alt="Screenshot 2024-01-23 at 9 47 52 AM" src="https://github.com/ray-project/travis-tracker-v2/assets/128072568/55e897b0-8a4b-4dfb-8b0d-8cfea0af5632">
