### PR TITLE
[ci] show weekly green metric on go/flaky

### DIFF
--- a/js/src/components/weeklygreen.tsx
+++ b/js/src/components/weeklygreen.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { Col, Row, Tooltip } from "antd";
+import { SiteWeeklyGreenMetric } from "../interface";
+import "./segment.css";
+
+interface Prop {
+  data: Array<SiteWeeklyGreenMetric>;
+}
+
+const WeeklyGreenMetric: React.FC<Prop> = ({ data }) => {
+  return (
+    <>
+      <button
+          style={{
+            backgroundColor: "rgba(220,220,220,0.3)",
+            margin: "8px",
+            marginTop: "16px",
+            padding: "8px",
+            paddingLeft: "16px",
+            borderRadius: "4px",
+            fontSize: "1.2em",
+            textAlign: "left",
+            width: "100%",
+            border: "none",
+            cursor: "pointer",
+          }}
+      >
+        <Row><Col>{"Daily green metric"}</Col></Row>
+      </button>
+      <div style={{ display: "flex", width: "90%", margin: "0 auto" }}>
+        {data.map((c) => {
+          let className = "item";
+          if (c.num_of_blockers > 0) {
+            className = `item failed`;
+          }
+
+          return (
+            <Tooltip key={c.date} title={<p>{c.date}</p>}>
+              <div className={className} />
+            </Tooltip>
+          );
+        })}
+      </div>
+    </>
+  );
+};
+
+export default WeeklyGreenMetric;

--- a/js/src/interface.ts
+++ b/js/src/interface.ts
@@ -63,9 +63,15 @@ export interface SiteFailedTest {
     owner: string;
 }
 
+export interface SiteWeeklyGreenMetric {
+    date: string;
+    num_of_blockers: number;
+}
+
 export interface SiteDisplayRoot {
     failed_tests: Array<SiteFailedTest>;
     stats: Array<SiteStatItem>;
+    weekly_green_metric: Array<SiteWeeklyGreenMetric>;
     test_owners: Array<string>;
     table_stat: string;
 }

--- a/js/src/pages/index.tsx
+++ b/js/src/pages/index.tsx
@@ -7,6 +7,7 @@ import LayoutWrapper from "../components/layout";
 import BuildTimeFooter from "../components/time";
 import Title from "../components/title";
 import TestCase from "../components/case";
+import WeeklyGreenMetric from "../components/weeklygreen";
 import StatsPane from "../components/stat";
 import { SiteDisplayRoot } from "../interface";
 import rawData from "../data.json";
@@ -62,6 +63,8 @@ const App: React.FC<PageProps<DataProps>> = ({ data, location }) => {
 
 
   const { dataSource, columns } = JSON.parse(displayData.table_stat);
+  
+  let weeklyGreenMetric = displayData.weekly_green_metric;
 
   let testsToDisplay = displayData.failed_tests;
   testsToDisplay = testsToDisplay.filter(
@@ -94,6 +97,8 @@ const App: React.FC<PageProps<DataProps>> = ({ data, location }) => {
         size={"small"}
         pagination={false}
       ></Table>
+
+      <WeeklyGreenMetric data={weeklyGreenMetric}></WeeklyGreenMetric>
 
       <Radio.Group
         style={{ paddingTop: "1%" }}

--- a/ray_ci_tracker/interfaces.py
+++ b/ray_ci_tracker/interfaces.py
@@ -92,9 +92,16 @@ class SiteFailedTest(Mixin):
 
 
 @dataclass
+class SiteWeeklyGreenMetric(Mixin):
+    date: str
+    num_of_blockers: int
+
+
+@dataclass
 class SiteDisplayRoot(Mixin):
     failed_tests: List[SiteFailedTest]
     stats: List[SiteStatItem]
+    get_weekly_green_metric: List[SiteWeeklyGreenMetric]
     test_owners: List[str]
     table_stat: str
 

--- a/ray_ci_tracker/interfaces.py
+++ b/ray_ci_tracker/interfaces.py
@@ -101,7 +101,7 @@ class SiteWeeklyGreenMetric(Mixin):
 class SiteDisplayRoot(Mixin):
     failed_tests: List[SiteFailedTest]
     stats: List[SiteStatItem]
-    get_weekly_green_metric: List[SiteWeeklyGreenMetric]
+    weekly_green_metric: List[SiteWeeklyGreenMetric]
     test_owners: List[str]
     table_stat: str
 


### PR DESCRIPTION
Compute the weekly green metric and show it on go/flaky. See attached green shot, the newly added data is the 'Daily green metric'

<img width="1853" alt="Screenshot 2024-01-24 at 1 56 59 PM" src="https://github.com/ray-project/travis-tracker-v2/assets/128072568/5d17f8a1-0e07-49b3-8cb8-64154b1d3a2c">
