### PR TITLE
Further skip big log size

### DIFF
--- a/ray_ci_tracker/data_source/github.py
+++ b/ray_ci_tracker/data_source/github.py
@@ -21,7 +21,7 @@ class GithubDataSource:
     @staticmethod
     async def _get_latest_commit() -> List[GHCommit]:
         resp = httpx.get(
-            "https://api.github.com/repos/ray-project/ray/commits?per_page=100",
+            "https://api.github.com/repos/ray-project/ray/commits?per_page=50",
             headers=GH_HEADERS,
         )
         assert resp.status_code == 200, "Pinging github API /commits failed"

--- a/ray_ci_tracker/data_source/github.py
+++ b/ray_ci_tracker/data_source/github.py
@@ -21,7 +21,7 @@ class GithubDataSource:
     @staticmethod
     async def _get_latest_commit() -> List[GHCommit]:
         resp = httpx.get(
-            "https://api.github.com/repos/ray-project/ray/commits?per_page=50",
+            "https://api.github.com/repos/ray-project/ray/commits?per_page=100",
             headers=GH_HEADERS,
         )
         assert resp.status_code == 200, "Pinging github API /commits failed"

--- a/ray_ci_tracker/data_source/github.py
+++ b/ray_ci_tracker/data_source/github.py
@@ -21,7 +21,7 @@ class GithubDataSource:
     @staticmethod
     async def _get_latest_commit() -> List[GHCommit]:
         resp = httpx.get(
-            "https://api.github.com/repos/ray-project/ray/commits?per_page=100",
+            "https://api.github.com/repos/ray-project/ray/commits?per_page=80",
             headers=GH_HEADERS,
         )
         assert resp.status_code == 200, "Pinging github API /commits failed"

--- a/ray_ci_tracker/data_source/s3.py
+++ b/ray_ci_tracker/data_source/s3.py
@@ -83,7 +83,7 @@ class S3DataSource:
                 object_key = fields[1]
                 if object_key.endswith("/"):
                     continue
-                if size > 100000000:
+                if size > 50000000:
                     print(f"Skipping {object_key} because it's too large: {size}")
                     exclude.append(object_key)
 

--- a/ray_ci_tracker/data_source/s3.py
+++ b/ray_ci_tracker/data_source/s3.py
@@ -83,7 +83,7 @@ class S3DataSource:
                 object_key = fields[1]
                 if object_key.endswith("/"):
                     continue
-                if size > 50000000:
+                if size > 100000000:
                     print(f"Skipping {object_key} because it's too large: {size}")
                     exclude.append(object_key)
 


### PR DESCRIPTION
go/flaky build currently runs out of space during download buildkite logs from s3; by reducing the number of commits on the page from 100 --> 80, the build now fits into github machine

Test:
- https://github.com/ray-project/travis-tracker-v2/actions/runs/11390748212