### PR TITLE
calculating failure and flaky rates as a percentage of all test runs

### DIFF
--- a/fetch_and_render.py
+++ b/fetch_and_render.py
@@ -462,7 +462,7 @@ class ResultsDB:
         records_to_insert = []
         for prefix in tqdm(dir_prefixes):
             if not os.path.exists(prefix):
-                # The direcotry dones't exists. It's fine
+                # The directory doesn't exist. It's fine
                 continue
             for build in os.listdir(prefix):
                 dir_name = Path(prefix) / build
@@ -657,14 +657,14 @@ class ResultsDB:
         cursor = self.table.execute(
             """
             -- Commit Tooltip
-            WITH filtered(sha, num_failed, num_flaky) AS (
-                SELECT sha, SUM(status == 'FAILED'), SUM(status == 'FLAKY') as num_failed
+            WITH filtered(sha, num_failed, num_flaky, num_passed) AS (
+                SELECT sha, SUM(status == 'FAILED'), SUM(status == 'FLAKY'), SUM(status == 'PASSED')
                 FROM test_result
                 WHERE test_name == (?)
                 GROUP BY sha
             )
             SELECT commits.sha, commits.message, commits.url, commits.avatar_url,
-                filtered.num_failed, filtered.num_flaky
+                filtered.num_failed, filtered.num_flaky, filtered.num_passed
             FROM commits LEFT JOIN filtered
             ON commits.sha == filtered.sha
             ORDER BY commits.idx
@@ -675,11 +675,12 @@ class ResultsDB:
             SiteCommitTooltip(
                 num_failed=num_failed,
                 num_flaky=num_flaky,
+                num_passed=num_passed,
                 message=msg,
                 author_avatar=avatar,
                 commit_url=url,
             )
-            for _, msg, url, avatar, num_failed, num_flaky in cursor.fetchall()
+            for _, msg, url, avatar, num_failed, num_flaky, num_passed in cursor.fetchall()
         ]
 
     def get_stats(self):

--- a/interfaces.py
+++ b/interfaces.py
@@ -52,6 +52,7 @@ class SiteTravisLink(Mixin):
 class SiteCommitTooltip(Mixin):
     num_failed: Optional[int]
     num_flaky: Optional[int]
+    num_passed: Optional[int]
     message: str
     author_avatar: str
     commit_url: str

--- a/js/src/components/case.tsx
+++ b/js/src/components/case.tsx
@@ -16,10 +16,15 @@ const getRate = (
   testCase: SiteFailedTest,
   mapFunc: (SiteCommitTooltip) => number
 ) => {
-  const totalFailed: number = testCase.status_segment_bar
+  const failAndFlaky: number = testCase.status_segment_bar
     .map(mapFunc)
     .reduce((a, b) => a + b);
-  return totalFailed;
+  
+  const totalRuns: number = testCase.status_segment_bar
+    .map(t => (t.num_passed || 0) + (t.num_failed || 0) + (t.num_flaky || 0))
+    .reduce((a, b) => a + b);
+
+  return totalRuns === 0 ? 0 : (failAndFlaky / totalRuns) * 100;
 };
 
 const TestCase: React.FC<Prop> = (props) => {

--- a/js/src/interface.ts
+++ b/js/src/interface.ts
@@ -42,6 +42,7 @@ export interface SiteTravisLink {
 export interface SiteCommitTooltip {
     num_failed: number | null;
     num_flaky: number | null;
+    num_passed: number | null;
     message: string;
     author_avatar: string;
     commit_url: string;

--- a/ray_ci_tracker/database.py
+++ b/ray_ci_tracker/database.py
@@ -383,14 +383,14 @@ class ResultsDBReader:
         cursor = self.table.execute(
             """
             -- Commit Tooltip
-            WITH filtered(sha, num_failed, num_flaky) AS (
-                SELECT sha, SUM(status == 'FAILED'), SUM(status == 'FLAKY') as num_failed
+            WITH filtered(sha, num_failed, num_flaky, num_passed) AS (
+                SELECT sha, SUM(status == 'FAILED'), SUM(status == 'FLAKY'), SUM(status == 'PASSED')
                 FROM test_result
                 WHERE test_name == (?)
                 GROUP BY sha
             )
             SELECT commits.sha, commits.message, commits.url, commits.avatar_url,
-                filtered.num_failed, filtered.num_flaky
+                filtered.num_failed, filtered.num_flaky, filtered.num_passed
             FROM commits LEFT JOIN filtered
             ON commits.sha == filtered.sha
             ORDER BY commits.idx
@@ -401,11 +401,12 @@ class ResultsDBReader:
             SiteCommitTooltip(
                 num_failed=num_failed,
                 num_flaky=num_flaky,
+                num_passed=num_passed,
                 message=msg,
                 author_avatar=avatar,
                 commit_url=url,
             )
-            for _, msg, url, avatar, num_failed, num_flaky in cursor.fetchall()
+            for _, msg, url, avatar, num_failed, num_flaky, num_passed in cursor.fetchall()
         ]
 
     def get_stats(self):

--- a/ray_ci_tracker/interfaces.py
+++ b/ray_ci_tracker/interfaces.py
@@ -68,6 +68,7 @@ class SiteTravisLink(Mixin):
 class SiteCommitTooltip(Mixin):
     num_failed: Optional[int]
     num_flaky: Optional[int]
+    num_passed: Optional[int]
     message: str
     author_avatar: str
     commit_url: str


### PR DESCRIPTION
Currently test failure and flaky rates were assuming that there were only 100 tests run on 100 commits. To fix this miscalculation:

Including number of passed test runs for percentage calculation
Only states for test runs are (FLAKY,FAILED,PASSED)

