### PR TITLE
removing weekly green metric from flaky test page

### DIFF
--- a/js/src/pages/index.tsx
+++ b/js/src/pages/index.tsx
@@ -7,7 +7,6 @@ import LayoutWrapper from "../components/layout";
 import BuildTimeFooter from "../components/time";
 import Title from "../components/title";
 import TestCase from "../components/case";
-import WeeklyGreenMetric from "../components/weeklygreen";
 import StatsPane from "../components/stat";
 import { SiteDisplayRoot } from "../interface";
 import rawData from "../data.json";
@@ -64,8 +63,6 @@ const App: React.FC<PageProps<DataProps>> = ({ data, location }) => {
 
   const { dataSource, columns } = JSON.parse(displayData.table_stat);
   
-  let weeklyGreenMetric = displayData.weekly_green_metric;
-
   let testsToDisplay = displayData.failed_tests;
   testsToDisplay = testsToDisplay.filter(
     (c) => ownerSelection === "all" || ownerSelection === c.owner
@@ -97,8 +94,6 @@ const App: React.FC<PageProps<DataProps>> = ({ data, location }) => {
         size={"small"}
         pagination={false}
       ></Table>
-
-      <WeeklyGreenMetric data={weeklyGreenMetric}></WeeklyGreenMetric>
 
       <Radio.Group
         style={{ paddingTop: "1%" }}


### PR DESCRIPTION
Removing weekly green metric component from flaky test page


![image](https://github.com/user-attachments/assets/315890be-d2e7-4b0d-9076-46d5a19cee66)


tested:
![Screenshot 2025-06-04 at 3 58 14 PM](https://github.com/user-attachments/assets/a2c50ece-ba57-4d63-a0d2-04c5771c9370)

